### PR TITLE
Return empty list for no results from Solr

### DIFF
--- a/authoraffsrv/views.py
+++ b/authoraffsrv/views.py
@@ -523,7 +523,7 @@ def search():
         result = Formatter(from_solr).get(num_authors, cutoff_year)
         if result is not None:
             return return_response(result, 200)
-    return return_response({'error': 'no result from solr'}, 404)
+    return return_response([], 200)
 
 
 @advertise(scopes=[], rate_limit=[1000, 3600 * 24])


### PR DESCRIPTION
Change error response to return an empty list instead of an error message.

This is not really an error, we got no results from solr, which is a valid response.  So I think it's better we return an empty list here.  

Also the 404 is not the best response code here since it sometimes requires special handling to determine if it's a 404 because the service was not found or if it was this error.